### PR TITLE
added the okHttp implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'io.github.cdimascio:dotenv-java:3.2.0'
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/ecommercespring/configuration/RetrofitConfig.java
+++ b/src/main/java/com/example/ecommercespring/configuration/RetrofitConfig.java
@@ -2,6 +2,9 @@ package com.example.ecommercespring.configuration;
 
 import com.example.ecommercespring.gateway.api.IFakeStoreCategoryApi;
 import com.example.ecommercespring.gateway.api.IFakeStoreProductApi;
+import com.google.gson.Gson;
+import okhttp3.OkHttp;
+import okhttp3.OkHttpClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -32,4 +35,14 @@ public class RetrofitConfig {
     return retrofit.create(IFakeStoreProductApi.class);
   }
 
+
+  @Bean
+  public OkHttpClient okHttp() {
+    return new OkHttpClient();
+  }
+
+  @Bean
+  public Gson gson() {
+    return new Gson();
+  }
 }

--- a/src/main/java/com/example/ecommercespring/gateway/FakeStoreCategoryGateway.java
+++ b/src/main/java/com/example/ecommercespring/gateway/FakeStoreCategoryGateway.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.util.List;
 
-@Component
+@Component("fakeStoreCategoryGateway")
 public class FakeStoreCategoryGateway implements ICategoryGateway {
 
     private final IFakeStoreCategoryApi fakeStoreCategoryApi;

--- a/src/main/java/com/example/ecommercespring/gateway/FakeStoreCategoryGatewayOkHttp.java
+++ b/src/main/java/com/example/ecommercespring/gateway/FakeStoreCategoryGatewayOkHttp.java
@@ -1,0 +1,37 @@
+package com.example.ecommercespring.gateway;
+
+import com.example.ecommercespring.dto.CategoryDTO;
+import com.example.ecommercespring.dto.FakeStoreCategoryResponseDTO;
+import com.example.ecommercespring.gateway.api.OkHttpRequest;
+import com.google.gson.Gson;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component("fakeStoreCategoryGatewayOkHttp")
+public class FakeStoreCategoryGatewayOkHttp implements ICategoryGateway{
+    private final OkHttpRequest okHttpRequest;
+    private final Gson gson;
+
+    public FakeStoreCategoryGatewayOkHttp(OkHttpRequest okHttpRequest, Gson gson) {
+        this.okHttpRequest = okHttpRequest;
+        this.gson = gson;
+    }
+
+    @Override
+    public List<CategoryDTO> getAllCategories() throws IOException {
+
+        String response = this.okHttpRequest.run("https://fakestoreapi.in/api/products/category");
+        FakeStoreCategoryResponseDTO fakeStoreCategoryResponseDTO = this.gson.fromJson(response,FakeStoreCategoryResponseDTO.class);
+        if (response==null){
+            throw new IOException("Failed to fetch all categories From FakeStoreAPI");
+        }
+        return fakeStoreCategoryResponseDTO.getCategories().stream()
+                .map(category->CategoryDTO.builder()
+                        .name(category)
+                        .build())
+                .toList();
+
+    }
+}

--- a/src/main/java/com/example/ecommercespring/gateway/api/OkHttpRequest.java
+++ b/src/main/java/com/example/ecommercespring/gateway/api/OkHttpRequest.java
@@ -1,0 +1,27 @@
+package com.example.ecommercespring.gateway.api;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class OkHttpRequest {
+    private final OkHttpClient client;
+
+    OkHttpRequest (OkHttpClient client) {
+        this.client = client;
+    }
+
+    public String run(String url) throws IOException {
+        Request request = new Request.Builder()
+                .url(url)
+                .build();
+
+        try (Response response = this.client.newCall(request).execute()) {
+            return response.body().string();
+        }
+    }
+}

--- a/src/main/java/com/example/ecommercespring/services/FakeStoreCateoryService.java
+++ b/src/main/java/com/example/ecommercespring/services/FakeStoreCateoryService.java
@@ -2,6 +2,7 @@ package com.example.ecommercespring.services;
 
 import com.example.ecommercespring.dto.CategoryDTO;
 import com.example.ecommercespring.gateway.ICategoryGateway;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -12,7 +13,7 @@ public class FakeStoreCateoryService implements  ICategoryService {
 
     private final ICategoryGateway categoryGateway;
 
-    public FakeStoreCateoryService(ICategoryGateway categoryGateway) {
+    public FakeStoreCateoryService(@Qualifier("fakeStoreCategoryGatewayOkHttp") ICategoryGateway categoryGateway) {
         this.categoryGateway = categoryGateway;
     }
 


### PR DESCRIPTION

## **Description**

This PR introduces **OkHttp** as an alternative HTTP client to Retrofit for the **`FakeStoreCategoryService`**, enabling flexible configuration of the HTTP client layer by injecting the desired implementation of `ICategoryGateway` using Spring’s `@Qualifier`.

Instead of modifying the existing Retrofit-based `FakeStoreCategoryGateway`, a new gateway implementation `FakeStoreCategoryGatewayOkHttp` has been added. The corresponding service (`FakeStoreCategoryService`) is now configured to use this new OkHttp-based gateway.

This makes the service layer pluggable and capable of switching between different HTTP clients (Retrofit or OkHttp) without modifying business logic or controller code.

---

## **Changes Made**

### 🔧 Gradle Dependency

* Added `OkHttp` dependency:

  ```groovy
  implementation 'com.squareup.okhttp3:okhttp:4.12.0'
  ```

---

### 🏗️ Gateway Layer

✅ **New Gateway Implementation**

* Created a new class `FakeStoreCategoryGatewayOkHttp` implementing `ICategoryGateway`.
* Uses:

  * `OkHttpClient` for sending HTTP requests.
  * `Gson` for deserializing responses.
  * A utility component `OkHttpRequest` to encapsulate the HTTP request logic.

✅ **Request Utility**

* Created a new component `OkHttpRequest` that abstracts raw OkHttp client usage.

---

### ⚙️ Configuration

✅ **OkHttp & Gson Beans**

* Defined `OkHttpClient` and `Gson` as beans in `RetrofitConfig`:

  ```java
  @Bean
  public OkHttpClient okHttp() {
    return new OkHttpClient();
  }

  @Bean
  public Gson gson() {
    return new Gson();
  }
  ```

---

### 💡 Service Layer

✅ **Updated FakeStoreCategoryService**

* Injected the new OkHttp-based gateway via Spring’s `@Qualifier`:

  ```java
  public FakeStoreCateoryService(@Qualifier("fakeStoreCategoryGatewayOkHttp") ICategoryGateway categoryGateway)
  ```
* No change required in business logic — abstraction remains intact through the `ICategoryGateway` interface.

---

## **Why This Change?**

✅ **Decouples service logic from specific HTTP client implementation**
✅ **Promotes modularity** — Retrofit and OkHttp can coexist and be swapped easily via DI
✅ **Prepares the codebase for future A/B testing or benchmarking across clients**
✅ **Improves testability** — multiple implementations of the same interface can be mocked or tested independently
✅ **Follows SOLID principles** — especially the Open/Closed Principle and Dependency Inversion

---

## **How to Use**

* By default, `FakeStoreCateoryService` now uses the `fakeStoreCategoryGatewayOkHttp` implementation.
* To switch back to the Retrofit-based gateway, change the qualifier in `FakeStoreCateoryService` constructor to:

  ```java
  @Qualifier("fakeStoreCategoryGateway")
  ```

---

## ✅ Additional Notes

* No changes were required in controller or DTOs.
* The gateway contract (`ICategoryGateway`) remains unchanged, ensuring compatibility.
* The product flow (`FakeStoreProductService`) still uses Retrofit and is unaffected by this change.

---
